### PR TITLE
Basic Http server / proxy skeleton completed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 *.exe
 *.out
 *.app
+bin/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+CC        := clang++
+SRCDIR    := src
+HEADERDIR := include
+BUILDDIR  := build
+TARGETDIR := bin
+TARGET    := $(TARGETDIR)/irin
+BOOSTDIR  := /usr/local/Cellar/boost/1.62.0
+
+SRCEXT    := cc
+HEADEREXT := h
+SOURCES   := $(shell find $(SRCDIR) -type f -name "*.$(SRCEXT)")
+HEADERS   := $(shell find $(HEADERDIR) -type f -name "*.$(HEADEREXT)")
+OBJECTS   := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
+CFLAGS    := -std=c++14
+DEVFLAGS  := $(CFLAGS) -g
+PRODFLAGS := $(CFLAGS) -O2
+INC       := $(BOOSTDIR)/include
+LIBS      := -lboost_system-mt -lboost_thread-mt -lboost_filesystem-mt -lboost_log-mt -lboost_log_setup-mt -lboost_program_options-mt
+
+$(TARGET): $(OBJECTS)
+	@echo "Linking..."
+	$(CC) $^ -o $(TARGET) -L $(BOOSTDIR)/lib $(LIBS)
+
+$(BUILDDIR)/%.o: $(SRCDIR)/%.$(SRCEXT)
+	@echo "Compiling..."
+	@mkdir -p $(BUILDDIR)/server
+	@mkdir -p $(TARGETDIR)
+	$(CC) $(DEVFLAGS) -I $(INC) -I include -DBOOST_LOG_DYN_LINK -c -o $@ $< 
+
+clean:
+	@echo "Cleaning..."
+	rm -r -f $(BUILDDIR) $(TARGETDIR)
+
+.PHONY: clean

--- a/include/server/content-service.h
+++ b/include/server/content-service.h
@@ -1,0 +1,22 @@
+#ifndef _CONTENT_SERVICE_HEADER_H_
+#define _CONTENT_SERVICE_HEADER_H_
+
+#include "boost/filesystem.hpp"
+#include "server/http-request.h"
+#include "server/http-response.h"
+#include <string>
+#include <vector>
+
+class ContentService {
+  public:
+    ContentService(const std::string& pages_dir);
+    std::unique_ptr<HttpResponse> Handle(const std::unique_ptr<HttpRequest> &request);
+  private:
+    boost::filesystem::path pages_dir_;
+    bool resource_exists(const std::string &resource);
+    std::vector<char> read_resource(const std::string &resource);
+    std::vector<char> read_404();
+    std::vector<char> read_file(const std::string &full_path);
+};
+
+#endif

--- a/include/server/dispatcher.h
+++ b/include/server/dispatcher.h
@@ -1,0 +1,20 @@
+#ifndef _DISPATCHER_HEADER_H_
+#define _DISPATCHER_HEADER_H_
+
+#include "server/content-service.h"
+#include "server/http-statuses.h"
+#include "server/transporter.h"
+
+class Dispatcher {
+  public:
+    Dispatcher(std::unique_ptr<ContentService> &service, std::unique_ptr<Transporter> &transporter);
+    void Run();
+  private:
+    std::unique_ptr<ContentService> service_;
+    std::unique_ptr<Transporter> transporter_;
+    std::string request_uri_root(const std::string &uri);
+    void log_request_response(const std::string &request_to_string,
+      const HttpStatus &status);
+};
+
+#endif

--- a/include/server/http-headers.h
+++ b/include/server/http-headers.h
@@ -1,0 +1,21 @@
+#ifndef _HTTP_HEADERS_HEADER_H_
+#define _HTTP_HEADERS_HEADER_H_
+
+#include <iostream>
+
+struct HttpHeader {
+  std::string name;
+  std::string value;
+};
+
+namespace HttpHeaders {
+  const std::string Server        = "Server";
+  const std::string ContentType   = "Content-Type";
+  const std::string ContentLength = "Content-Length";
+  const std::string Connection    = "Connection";
+  const std::string Date          = "Date";
+  const std::string CacheControl  = "Cache-Control";
+  const std::string Status        = "Status";
+}
+
+#endif

--- a/include/server/http-methods.h
+++ b/include/server/http-methods.h
@@ -1,0 +1,34 @@
+#ifndef _HTTP_METHODS_HEADER_H_
+#define _HTTP_METHODS_HEADER_H_
+
+#include <string>
+
+struct HttpMethod {
+  std::string to_string;
+};
+
+namespace HttpMethods {
+  const HttpMethod Get{"GET"};
+  const HttpMethod Head{"HEAD"};
+  const HttpMethod Post{"POST"};
+  const HttpMethod Put{"PUT"};
+  const HttpMethod Delete{"DELETE"};
+  const HttpMethod Trace{"TRACE"};
+  const HttpMethod Patch{"PATCH"};
+
+  static HttpMethod from_string(std::string &str) {
+    HttpMethod method;
+    if(str.compare(HttpMethods::Get.to_string) == 0) method = HttpMethods::Get;
+    else if(str.compare(HttpMethods::Head.to_string) == 0) method = HttpMethods::Head;
+    else if(str.compare(HttpMethods::Post.to_string) == 0) method = HttpMethods::Post;
+    else if(str.compare(HttpMethods::Put.to_string) == 0) method = HttpMethods::Put;
+    else if(str.compare(HttpMethods::Delete.to_string) == 0) method = HttpMethods::Delete;
+    else if(str.compare(HttpMethods::Trace.to_string) == 0) method = HttpMethods::Trace;
+    else if(str.compare(HttpMethods::Patch.to_string) == 0) method = HttpMethods::Patch;
+    else throw new std::out_of_range("terribel exception");
+
+    return method;
+  };
+};
+
+#endif

--- a/include/server/http-request.h
+++ b/include/server/http-request.h
@@ -1,0 +1,24 @@
+#ifndef _HTTP_REQUEST_HEADER_H_
+#define _HTTP_REQUEST_HEADER_H_
+
+#include "server/http-methods.h"
+#include "server/http-versions.h"
+#include <string>
+#include <vector>
+
+class HttpRequest {
+  public:
+    HttpRequest(std::vector<char> vec);
+    inline HttpMethod Method() { return method_; };
+    inline std::string RequestUri() {return request_uri_; };
+    std::string ToString();
+  private:
+    HttpMethod method_;
+    HttpVersion version_;
+    std::string request_uri_;
+    void parse_request_line(const std::vector<char> &req_line_chars);
+    static std::vector<char> copy_vector_splice(const std::vector<char> &vector, 
+        const int start_idx, const int end_idx);
+};
+
+#endif

--- a/include/server/http-response.h
+++ b/include/server/http-response.h
@@ -1,0 +1,28 @@
+#ifndef _HTTP_RESPONSE_HEADER_H_
+#define _HTTP_RESPONSE_HEADER_H_
+
+#include <boost/asio.hpp>
+#include <boost/optional.hpp>
+#include "server/http-statuses.h"
+#include "server/http-headers.h"
+#include <string>
+#include <vector>
+
+class HttpResponse {
+  public:
+    HttpResponse(const HttpStatus http_status);
+    HttpResponse(const HttpStatus http_status, const std::vector<char>& body);
+    size_t WriteToArray(char array[]);
+    HttpStatus GetHttpStatus() { return http_status_; };
+  private:
+    HttpStatus http_status_;
+    boost::optional<std::vector<char>> body_;
+    std::vector<HttpHeader> headers_;
+    std::vector<HttpHeader> build_headers();
+    std::string build_response_string();
+    std::string dateString();
+    int body_size();
+    std::string body();
+};
+
+#endif

--- a/include/server/http-statuses.h
+++ b/include/server/http-statuses.h
@@ -1,0 +1,16 @@
+#ifndef _HTTP_STATUSES_HEADER_H_
+#define _HTTP_STATUSES_HEADER_H_
+
+#include <string>
+
+struct HttpStatus {
+  short code;
+  std::string response;
+};
+
+namespace HttpStatuses {
+  const HttpStatus Ok{200, "OK"};
+  const HttpStatus NotFound{404, "NOT FOUND"};
+}
+
+#endif

--- a/include/server/http-versions.h
+++ b/include/server/http-versions.h
@@ -1,0 +1,29 @@
+#ifndef _HTTP_VERSIONS_HEADER_H_
+#define _HTTP_VERSIONS_HEADER_H_
+
+#include <string>
+
+struct HttpVersion {
+  std::string to_string;
+};
+
+namespace HttpVersions {
+  const HttpVersion HttpVersion_1_0{"HTTP/1.0"};
+  const HttpVersion HttpVersion_1_1{"HTTP/1.1"};
+  const HttpVersion HttpVersion_2_0{"HTTP/2.0"};
+
+  static HttpVersion from_string(std::string &str) {
+    HttpVersion version;
+    if(str.compare(HttpVersions::HttpVersion_1_0.to_string) == 0) 
+      version = HttpVersions::HttpVersion_1_0;
+    else if(str.compare(HttpVersions::HttpVersion_1_1.to_string) == 0) 
+      version = HttpVersions::HttpVersion_1_1;
+    else if(str.compare(HttpVersions::HttpVersion_2_0.to_string) == 0) 
+      version = HttpVersions::HttpVersion_2_0;
+    else throw new std::out_of_range("terribel exception");
+
+    return version;
+  };
+};
+
+#endif

--- a/include/server/proxy-service.h
+++ b/include/server/proxy-service.h
@@ -1,0 +1,23 @@
+#ifndef _PROXY_SERVICE_HEADER_H_
+#define _PROXY_SERVICE_HEADER_H_
+
+#include "boost/asio.hpp"
+#include "server/http-request.h"
+#include "server/http-response.h"
+#include <string>
+
+using boost::asio::ip::tcp;
+
+class ProxyService {
+  public:
+    ProxyService() : resolver_(io_service_), socket_(io_service_) {};
+    std::unique_ptr<HttpResponse> Handle(const std::unique_ptr<HttpRequest> &http_request);
+  private:
+    boost::asio::io_service io_service_;
+    tcp::resolver resolver_;
+    tcp::socket socket_;
+    void build_request(boost::asio::streambuf &tcp_request, const
+      std::unique_ptr<HttpRequest> &http_request);
+};
+
+#endif

--- a/include/server/transporter.h
+++ b/include/server/transporter.h
@@ -1,0 +1,28 @@
+#ifndef _TRANSPORTER_HEADER_H_
+#define _TRANSPORTER_HEADER_H_
+
+#include <boost/asio.hpp>
+#include "server/http-request.h"
+#include "server/http-response.h"
+#include "server/http-methods.h"
+#include <vector>
+
+using boost::asio::ip::tcp;
+
+class Transporter {
+  public:
+    Transporter(short port);
+    std::unique_ptr<HttpRequest> Read();
+    void Write(const std::unique_ptr<HttpResponse> &response);
+  private:
+    short port_;
+    char data_[2048];
+    boost::asio::io_service io_service_;
+    tcp::acceptor acceptor_;
+    tcp::socket socket_;
+    std::vector<char> slice_read_chars(size_t num_chars);
+    static const int kBufferSize = 7340032; // 7 MB
+    char write_buffer_[kBufferSize];
+};
+
+#endif

--- a/pages/404.html
+++ b/pages/404.html
@@ -1,0 +1,12 @@
+<!-- 404.html -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="author" content="penland365">
+    <title>404 - irin</title>
+  </head>
+  <body>
+    <h1>404 Not Found</h1>
+  </body>
+</html>

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,0 +1,78 @@
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include "boost/program_options.hpp"
+#include "server/dispatcher.h"
+#include "server/transporter.h"
+
+std::string build_log_info(const int &port, const std::string &dir);
+
+namespace {
+  const size_t kSuccess = 0;
+  const size_t kErrorInCommandLine = 1;
+  const size_t kErrorUnhandledException = 2;
+  const std::string kVersionNumber = "0.0.1";
+}
+
+int main(int argc, char** argv) {
+
+  try {
+    namespace po = boost::program_options;
+    po::options_description desc("Options");
+    desc.add_options()
+      ("help,h", "Print help message")
+      ("directory,d", po::value<std::string>()->required(), "Required Absolute PATH for the pages directory")
+      ("version,v", "Print the version number")
+      ("port,p", "Port on which traffic will be served. DEFAULT: 8000");
+    po::variables_map vm;
+    try {
+      po::store(po::parse_command_line(argc, argv, desc), vm);
+      if(vm.count("directory")) {
+        std::string pages_dir = vm["directory"].as<std::string>();
+        int port = 8000;
+
+        BOOST_LOG_TRIVIAL(info) << build_log_info(port, pages_dir);
+        std::unique_ptr<ContentService> service(new ContentService(pages_dir));
+        std::unique_ptr<Transporter> transporter(new Transporter(port));
+        std::unique_ptr<Dispatcher> dispatcher(new Dispatcher(service, transporter));
+
+        dispatcher->Run();
+      } else if(vm.count("directory") && vm.count("port")) {
+        std::string pages_dir = vm["directory"].as<std::string>();
+        int port = vm["port"].as<int>();
+
+        BOOST_LOG_TRIVIAL(info) << build_log_info(port, pages_dir);
+        std::unique_ptr<ContentService> service(new ContentService(pages_dir));
+        std::unique_ptr<Transporter> transporter(new Transporter(port));
+        std::unique_ptr<Dispatcher> dispatcher(new Dispatcher(service, transporter));
+
+        dispatcher->Run(); 
+      } else if(vm.count("help")) {
+        std::cout << "irin - a simple webserver and transpiler to help build React applications"
+          << std::endl;
+        std::cout << std::endl;
+        std::cout << desc << std::endl;
+        return kSuccess;
+      } else if(vm.count("version")) {
+        std::cout << "version " << kVersionNumber << std::endl;
+        std::cout << "built " << __DATE__ << " " << __TIME__ << std::endl;
+        return kSuccess;
+      }
+      po::notify(vm);
+    } catch(po::error& error) {
+      std::cerr << "ERROR: " << error.what() << std::endl << std::endl;
+      std::cerr << desc << std::endl;
+      return kErrorInCommandLine;
+    }
+  } catch (std::exception &ex) {
+    BOOST_LOG_TRIVIAL(fatal) << ex.what();
+    return kErrorUnhandledException;
+  }
+
+  return kSuccess;
+};
+
+std::string build_log_info(const int &port, const std::string &dir) {
+  auto info_fmt = boost::format("Serving on port %1% with pages at %2%")
+    % port % dir;
+  return info_fmt.str();
+};

--- a/src/server/content-service.cc
+++ b/src/server/content-service.cc
@@ -1,0 +1,51 @@
+#include "server/content-service.h"
+#include <fstream>
+#include <sstream>
+
+ContentService::ContentService(const std::string &pages_dir) {
+  this->pages_dir_ = boost::filesystem::path(pages_dir);
+};
+
+std::unique_ptr<HttpResponse> ContentService::Handle(const std::unique_ptr<HttpRequest> &request) {
+  if(!resource_exists(request->RequestUri())) {
+    auto resource_404 = read_404();
+    return std::unique_ptr<HttpResponse>(new HttpResponse(HttpStatuses::NotFound, resource_404));
+  }
+
+  auto body = read_resource(request->RequestUri());
+  std::unique_ptr<HttpResponse> response(new HttpResponse(HttpStatuses::Ok, body));
+  return response;
+};
+
+bool ContentService::resource_exists(const std::string &resource) {
+  boost::filesystem::path full_path( boost::filesystem::current_path() );
+  auto full_path_resource = full_path.string() + resource;
+  bool exists = boost::filesystem::exists(full_path_resource);
+  if(!exists) return false;
+
+  return !boost::filesystem::is_directory(full_path_resource);
+};
+
+std::vector<char> ContentService::read_resource(const std::string &resource) {
+  boost::filesystem::path full_path( boost::filesystem::current_path() );
+  auto full_path_resource = full_path.string() + resource;
+
+  return read_file(full_path_resource);
+};
+
+std::vector<char> ContentService::read_404() {
+  auto full_path_resource = pages_dir_.string() + boost::filesystem::path::preferred_separator
+    + "404.html";
+  return read_file(full_path_resource);
+};
+
+std::vector<char> ContentService::read_file(const std::string &full_path) {
+  std::ifstream input_stream(full_path);
+  std::stringstream sstream;
+  std::string line;
+  while(getline(input_stream, line))
+    sstream << line << std::endl;
+
+  auto body_line = sstream.str();
+  return std::vector<char>(body_line.begin(), body_line.end());
+};

--- a/src/server/dispatcher.cc
+++ b/src/server/dispatcher.cc
@@ -1,0 +1,63 @@
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include "server/content-service.h"
+#include "server/http-request.h"
+#include "server/dispatcher.h"
+#include "server/proxy-service.h"
+#include <iostream>
+
+Dispatcher::Dispatcher(std::unique_ptr<ContentService> &service, 
+  std::unique_ptr<Transporter> &transporter) {
+    this->service_     = std::move(service);
+    this->transporter_ = std::move(transporter);
+};
+
+void Dispatcher::Run() {
+  std::unique_ptr<ProxyService> proxy_service(new ProxyService());
+
+  while(true) {
+    std::unique_ptr<HttpRequest> request = transporter_->Read();
+
+    std::unique_ptr<HttpResponse> response;
+    auto root = request_uri_root(request->RequestUri());
+    if(root.compare("/api") == 0)
+      response = proxy_service->Handle(request);
+    else
+      response = service_->Handle(request);
+
+    log_request_response(request->ToString(), response->GetHttpStatus());
+    transporter_->Write(response);
+  }
+};
+
+std::string Dispatcher::request_uri_root(const std::string &uri) {
+  bool second_separator_found = false;
+  int idx = 0;
+  int separator_count = 0;
+  size_t uri_size = uri.size();
+  while(!second_separator_found && idx < uri_size) {
+    if(uri[idx] == '/') {
+      ++separator_count;
+      if(separator_count == 2)
+        second_separator_found = true;
+      else
+        ++idx;
+    } else {
+      ++idx;
+    }
+  }
+
+  if(!second_separator_found)
+    return uri;
+
+  return std::string(uri.begin(), uri.begin() + idx);
+};
+
+void Dispatcher::log_request_response(const std::string &request_to_string, 
+    const HttpStatus &status) {
+    auto fmt = boost::format("%1% %2% %3%")
+      % request_to_string
+      % status.code
+      % status.response;
+    BOOST_LOG_TRIVIAL(info) << fmt.str();
+};

--- a/src/server/http-request.cc
+++ b/src/server/http-request.cc
@@ -1,0 +1,77 @@
+#include <boost/format.hpp>
+#include "server/http-methods.h"
+#include "server/http-request.h"
+#include <iostream>
+
+HttpRequest::HttpRequest(std::vector<char> req) {
+  bool eol = false;
+  int idx = 0;
+  while(!eol) {
+    if(idx > req.size()) {
+      eol = true;
+    } else {
+      char ch = req[idx];
+      if(ch == '\r' || ch =='\n')
+        eol = true;
+      else
+        ++idx;
+    }
+  }
+  auto request_line_vector = copy_vector_splice(req, 0, idx);
+  parse_request_line(request_line_vector);
+};
+
+void HttpRequest::parse_request_line(const std::vector<char> &req_line_chars) {
+
+  // parse out request method
+  int idx = 0;
+  bool whitespace_found = false;
+  while(!whitespace_found) {
+    if(idx > req_line_chars.size())
+      throw new std::out_of_range("asdf");
+    if(req_line_chars[idx] == ' ')
+      whitespace_found = true;
+    else
+      ++idx;
+  }
+  std::string method_str(req_line_chars.begin(), req_line_chars.begin() + idx);
+  this->method_  = HttpMethods::from_string(method_str);
+
+  // parse out request_uri
+  whitespace_found = false;
+  ++idx;
+  int start_idx = idx;
+  while(!whitespace_found) {
+    if(idx > req_line_chars.size())
+      throw new std::out_of_range("asdf");
+    if(req_line_chars[idx] == ' ')
+      whitespace_found = true;
+    else
+      ++idx;
+  }
+  this->request_uri_ = std::string(req_line_chars.begin() + start_idx, 
+      req_line_chars.begin() + idx);
+
+  // parse out http version
+  std::string version_str(req_line_chars.begin() + idx + 1, req_line_chars.end());
+  this->version_ = HttpVersions::from_string(version_str);
+};
+
+std::vector<char> HttpRequest::copy_vector_splice(const std::vector<char> &vector,
+  const int start_idx, const int end_idx) {
+  std::vector<char> return_vector;
+  return_vector.reserve(end_idx - start_idx);
+  for(int idx = start_idx;idx < end_idx;++idx) {
+    char elem = vector[idx];
+    return_vector.push_back(elem);
+  }
+
+  return return_vector;
+};
+
+std::string HttpRequest::ToString() {
+  auto fmt = boost::format("%1% %2%")
+    % method_.to_string
+    % request_uri_;
+  return fmt.str();
+};

--- a/src/server/http-response.cc
+++ b/src/server/http-response.cc
@@ -1,0 +1,107 @@
+#include <boost/asio.hpp>
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/optional.hpp>
+#include <ctime>
+#include "server/http-response.h"
+#include "server/http-headers.h"
+#include <locale>
+
+HttpResponse::HttpResponse(const HttpStatus http_status) {
+  this->http_status_ = http_status;
+  this->body_ = boost::none;
+};
+
+HttpResponse::HttpResponse(const HttpStatus http_status, const std::vector<char>& body) {
+  this->http_status_ = http_status;
+  this->body_ = body;
+};
+
+std::string HttpResponse::dateString() {
+  auto locale = std::locale("");
+  auto now = std::time(nullptr);
+  auto timeinfo = std::localtime(&now);
+  char buffer[80];
+  std::strftime(buffer,80,"%a, %d %b %G %H:%M:%S %Z", timeinfo);
+  std::string str(buffer);
+  return str;
+};
+
+std::vector<HttpHeader> HttpResponse::build_headers() {
+  auto status_fmt = boost::format("%1% %2%")
+    % this->http_status_.code 
+    % this->http_status_.response;
+
+  auto server         = HttpHeader{HttpHeaders::Server, "Irin"};
+  auto date           = HttpHeader{HttpHeaders::Date, this->dateString()};
+  auto content_type   = HttpHeader{HttpHeaders::ContentType, "text/html; chatset=utf-8"};
+  auto status         = HttpHeader{HttpHeaders::Status, status_fmt.str()};
+  auto cache_control  = HttpHeader{HttpHeaders::CacheControl, "no-cache"};
+  auto body_length    = this->body_size();
+  auto body_len_str   = (body_length != 0) ? std::to_string(body_length + 1) : "0"; // trailing NULL
+  auto content_length = HttpHeader{HttpHeaders::ContentLength, body_len_str};
+  auto connection     = HttpHeader{HttpHeaders::Connection, "close"};
+
+  std::vector<HttpHeader> headers;
+  headers.reserve(7);
+  headers.push_back(server);
+  headers.push_back(date);
+  headers.push_back(content_type);
+  headers.push_back(status);
+  headers.push_back(cache_control);
+  headers.push_back(content_length);
+  headers.push_back(connection);
+  return headers;
+};
+
+size_t HttpResponse::WriteToArray(char array[]) {
+  std::string response_string = build_response_string();
+
+  size_t num_bytes = 0;
+  auto string_size = response_string.size(); 
+  while(num_bytes < string_size) {
+    array[num_bytes] = response_string[num_bytes];
+    ++num_bytes;
+  }
+  ++num_bytes;
+  array[num_bytes] = '\0';
+
+  return num_bytes;
+};
+
+std::string HttpResponse::build_response_string() {
+  auto headers = this->build_headers();
+  auto response_line_fmt = boost::format("HTTP/1.1 %1% %2%\r\n")
+    % this->http_status_.code 
+    % this->http_status_.response;
+  auto header_str = response_line_fmt.str();
+  for(const auto &header : headers) {
+    auto line = header.name + ": " + header.value + "\r\n";
+    header_str += line;
+  }
+  header_str += "\r\n";
+  return header_str + this->body();
+};
+
+std::string HttpResponse::body() {
+  std::string body = "";
+  try {
+    std::vector<char> body = this->body_.value();
+    std::string fbod(body.begin(), body.end());
+    return fbod;
+  } catch (const boost::bad_optional_access&) {
+    return "";
+  }
+  return body;
+};
+
+int HttpResponse::body_size() {
+  int size = 0;
+  try {
+    std::vector<char> body = this->body_.value();
+    size = body.size();
+  } catch (const boost::bad_optional_access&) {
+    size = 0;
+  }
+  return size;
+};

--- a/src/server/proxy-service.cc
+++ b/src/server/proxy-service.cc
@@ -1,0 +1,69 @@
+#include "boost/format.hpp"
+#include <boost/log/trivial.hpp>
+#include "server/proxy-service.h"
+
+std::unique_ptr<HttpResponse> ProxyService::Handle(const 
+  std::unique_ptr<HttpRequest> &http_request) {
+    BOOST_LOG_TRIVIAL(info) << "Entering ProxyService::Handle()";
+
+    boost::asio::streambuf tcp_request;
+    build_request(tcp_request, http_request);
+
+    tcp::resolver::query query("127.0.0.1", "9000");
+  //auto resolved = resolver_.resolve(query);
+  //std::cout << "queried" << std::endl;
+  //boost::asio::connect(socket_.lowest_layer(), resolver_.resolve(query));
+  //std::cout << "connected" << std::endl;
+  //socket_.lowest_layer().set_option(tcp::no_delay(true));
+
+  boost::asio::io_service io;
+  tcp::resolver resolv(io);
+  tcp::resolver::iterator endpoint_iterator = resolv.resolve(query);
+  tcp::socket socket(io);
+  boost::asio::connect(socket, endpoint_iterator);
+
+
+  // Send the request.
+  boost::asio::write(socket, tcp_request);
+  boost::asio::streambuf response;
+  boost::asio::read_until(socket, response, "\r\n");
+
+  // read status line
+  std::istream response_stream(&response);
+  std::string http_version;
+  response_stream >> http_version;
+  unsigned int status_code;
+  response_stream >> status_code;
+  std::string status_message;
+  std::cout << http_version << " " << status_code << " " << status_message << std::endl;
+
+  if (response.size() > 0)
+    std::cout << &response;
+  // read headers
+  boost::asio::read_until(socket, response, "\r\n\r\n");
+  std::string header;
+  while (std::getline(response_stream, header) && header != "\r")
+    std::cout << header << "\n";
+  std::cout << "\n";
+
+  // read the rest
+  boost::system::error_code error;
+  while (boost::asio::read(socket, response, boost::asio::transfer_at_least(1), error))
+    std::cout << &response;
+
+  std::unique_ptr<HttpResponse> resp(new HttpResponse(HttpStatuses::NotFound));
+  return resp;
+};
+
+void ProxyService::build_request(boost::asio::streambuf &tcp_request, const
+  std::unique_ptr<HttpRequest> &http_request) {
+
+    std::ostream request_stream(&tcp_request);
+    //auto formatter = boost::format("POST /api/status.json_token=%2% HTTP/1.1\r\n") % kFacebookGraphVersion % access_token_;
+
+    request_stream << "GET /api/status.json HTTP/1.1\r\n";
+    request_stream << "User-Agent: irin-proxy\r\n";
+    request_stream << "Content-Type: application/json\r\n";
+   // request_stream << "Content-Length: " << json_string_.length() << "\r\n";
+    request_stream << "Connection: close\r\n\r\n";
+};

--- a/src/server/transporter.cc
+++ b/src/server/transporter.cc
@@ -1,0 +1,46 @@
+#include <boost/asio.hpp>
+#include "server/http-request.h"
+#include "server/transporter.h"
+#include <iostream>
+
+using boost::asio::ip::tcp;
+
+Transporter::Transporter(short port) : 
+  acceptor_(io_service_, tcp::endpoint(tcp::v4(), port)),
+  socket_(io_service_) {
+    this->port_ = port;
+  for(int i = 0;i < kBufferSize;++i)
+    write_buffer_[i] = ' ';
+};
+
+std::unique_ptr<HttpRequest> Transporter::Read() {
+  acceptor_.accept(socket_);
+  boost::system::error_code error;
+  size_t length = socket_.read_some(boost::asio::buffer(data_), error);
+  std::vector<char> request_bytes = slice_read_chars(length);
+  std::unique_ptr<HttpRequest> req(new HttpRequest(request_bytes));
+  return req;
+};
+
+void Transporter::Write(const std::unique_ptr<HttpResponse> &response) {
+  boost::system::error_code shutdown_error;
+  boost::system::error_code ignored_error;
+
+  // write response to the wire
+  auto num_bytes    = response->WriteToArray(write_buffer_);
+  auto const_buffer = boost::asio::const_buffers_1(write_buffer_, num_bytes);
+  boost::asio::write(socket_, const_buffer, ignored_error);
+
+  // close off connection
+  socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, shutdown_error);
+  boost::system::error_code socket_close_err;
+  socket_.close(socket_close_err);
+};
+
+std::vector<char> Transporter::slice_read_chars(size_t num_chars) {
+  std::vector<char> chars;
+  chars.reserve(num_chars);
+  for(int idx = 0;idx < num_chars;++idx)
+    chars.push_back(data_[idx]);
+  return chars;
+};


### PR DESCRIPTION
The webserver can accept basic GET requests and read static
content from the disk. From a proxy standpoint, we can "forward"
the basic request line from the original Http Request, but we are
not sending the "complete request" as of yet. The response from
the proxy service is merely writing to the logs, and a new
and independant 404 Reponse is sent back to the original client.